### PR TITLE
Synthesize observedGeneration annotation for parents without native support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,11 +58,11 @@ The system identifies controllers by tracking which users update parent status v
 
 **Recording:**
 - Child CREATE/UPDATE (spec change only): hash added to child's `updaters` annotation (sync, via patch)
-- Parent status UPDATE: hash added to parent's `controllers` annotation (sync, via direct API call)
+- Parent status UPDATE: hash added to parent's `controllers` annotation (sync, via direct API call), plus `kausality.io/observedGeneration` set to current generation (synthetic observedGeneration for parents without native `status.observedGeneration`)
 
 Metadata-only changes do NOT record updaters - only spec changes do.
 
-Note: Controllers annotation uses direct API call because status subresource patches to metadata are ignored by Kubernetes.
+Note: Controllers and observedGeneration annotations use direct API calls because status subresource patches to metadata are ignored by Kubernetes.
 
 **Detection logic:**
 ```

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Kausality distinguishes between:
 
 Kausality tracks who updates what:
 
-1. **Parent status updates** → records the controller's identity
+1. **Parent status updates** → records the controller's identity and synthesizes `observedGeneration` for parents that lack native `status.observedGeneration`
 2. **Child spec updates** → checks if this is the same controller
 3. **Stable parent** (`generation == observedGeneration`) + **controller update** = **drift**
 
@@ -284,7 +284,7 @@ Kausality handles resource lifecycle:
 Initialization is detected via:
 - `kausality.io/phase: initialized` annotation
 - `Initialized=True` or `Ready=True` conditions
-- `observedGeneration` matching `generation`
+- `observedGeneration` matching `generation` (native, condition-based, or synthetic `kausality.io/observedGeneration` annotation)
 
 ### Audit Annotations
 

--- a/api/v1alpha1/annotations.go
+++ b/api/v1alpha1/annotations.go
@@ -37,6 +37,11 @@ const (
 	// SnoozeAnnotation indicates drift callbacks are temporarily suppressed.
 	// Value: JSON Snooze object, or legacy RFC3339 timestamp.
 	SnoozeAnnotation = "kausality.io/snooze"
+
+	// ObservedGenerationAnnotation stores the generation observed by the controller.
+	// Written on status updates; used as fallback when status.observedGeneration is absent.
+	// Value: string representation of int64 generation.
+	ObservedGenerationAnnotation = "kausality.io/observedGeneration"
 )
 
 // Phase values for the PhaseAnnotation.

--- a/doc/design/INDEX.md
+++ b/doc/design/INDEX.md
@@ -43,6 +43,7 @@ Kausality detects when controllers make unexpected changes to child resources an
 | `kausality.io/rejections` | Explicitly blocked mutations |
 | `kausality.io/freeze` | Emergency lockdown (blocks ALL changes) |
 | `kausality.io/snooze` | Suppress drift callbacks until expiry |
+| `kausality.io/observedGeneration` | Synthetic observedGeneration (from status updates) |
 | `kausality.io/mode` | `log` or `enforce` |
 
 ### Admission Flow Summary

--- a/doc/design/TRACING.md
+++ b/doc/design/TRACING.md
@@ -38,7 +38,7 @@ Namespace is omitted — it's the same as the object carrying the trace (or clus
 
 **Origin (new trace):**
 - No controller ownerReference, OR
-- Parent has `generation == observedGeneration` (no active reconciliation), OR
+- Parent has `generation == observedGeneration` (no active reconciliation — includes the synthetic `kausality.io/observedGeneration` annotation for parents without native `status.observedGeneration`), OR
 - Request user is not identified as the controller (via user hash tracking)
 - → Start new trace, this user is the initiator
 


### PR DESCRIPTION
## Summary

- Add `kausality.io/observedGeneration` annotation constant and record it on every parent status update (via direct API call and best-effort admission patch)
- Extend `Tracker.RecordControllerAsync`/`flushAfterDelay` to write the generation alongside the controller hash
- Read the annotation as third fallback in both `extractParentState` (resolver) and `extractParentStateFromObject` (handler), after native `status.observedGeneration` and Crossplane condition-based observedGeneration
- Add the annotation to `systemAnnotations` for correct preservation across child mutations

## Context

Parents like CAPI Clusters don't have `status.observedGeneration`. Without it, kausality can't determine if the parent is reconciling or stable, so it defaults to treating changes as new origins rather than detecting drift.

When a controller updates status, it has necessarily "observed" the current generation. By recording `obj.GetGeneration()` as `kausality.io/observedGeneration`, we get a synthetic observedGeneration for any resource — enabling proper drift detection even for resources without native support.

**Precedence:** `status.observedGeneration` > condition observedGeneration (Crossplane) > `kausality.io/observedGeneration` annotation

## Test plan

- [x] Unit tests for resolver annotation fallback (`TestExtractParentState_SyntheticObservedGeneration`) — 5 cases covering precedence, fallback, invalid values
- [x] Unit tests for `computeAnnotationsForStatusUpdate` with generation parameter — 6 cases
- [x] `make test` passes (all packages)
- [x] `make lint` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)