### PR TITLE
trace: controller always extends parent trace

### DIFF
--- a/pkg/trace/propagator.go
+++ b/pkg/trace/propagator.go
@@ -102,33 +102,36 @@ func (p *Propagator) Propagate(ctx context.Context, obj client.Object, user stri
 // Origin conditions:
 // - No controller ownerReference
 // - Request is from a different actor (not the controller)
-// - Parent has generation == observedGeneration (not reconciling)
-// - Parent has no observedGeneration and user is not confirmed as controller
+// - Can't determine controller identity and parent is stable or has no observedGeneration
+//
+// Confirmed controllers always extend the parent's trace regardless of parent state.
+// Whether the controller's action is expected (reconciling) or drift (parent stable)
+// doesn't change the causal chain — the action is still caused by the parent.
 func (p *Propagator) isOrigin(parentState *drift.ParentState, username string, childUpdaters []string) bool {
 	if parentState == nil {
 		return true
 	}
 
-	// Check controller identity first
 	isController, canDetermine := drift.IsControllerByHash(parentState, username, childUpdaters)
+
+	// Different actor = always origin (new causal chain)
 	if canDetermine && !isController {
-		return true // different actor = always origin
+		return true
 	}
 
-	// If parent has observedGeneration, use it
-	if parentState.HasObservedGeneration {
-		if parentState.Generation == parentState.ObservedGeneration {
-			return true // parent stable = origin
-		}
-		return false // parent reconciling, user is/might be controller = extend
-	}
-
-	// No observedGeneration: can't determine reconciliation state.
-	// Only extend if user is confirmed as the controller.
+	// Confirmed controller = always extend parent's trace.
+	// The controller's action is causally linked to the parent regardless of parent state.
 	if canDetermine && isController {
-		return false // confirmed controller = extend
+		return false
 	}
-	return true // unknown = origin (safer default)
+
+	// Can't determine controller identity.
+	// If parent is reconciling, assume extend (likely controller).
+	if parentState.HasObservedGeneration && parentState.Generation != parentState.ObservedGeneration {
+		return false
+	}
+
+	return true // unknown actor, parent stable or no obsGen → origin (safer default)
 }
 
 // getParentTrace retrieves the trace from the parent object.

--- a/pkg/trace/propagator_test.go
+++ b/pkg/trace/propagator_test.go
@@ -32,7 +32,7 @@ func TestPropagator_isOrigin(t *testing.T) {
 
 		// === Has observedGeneration ===
 		{
-			name: "has obsGen + stable + is controller - origin",
+			name: "has obsGen + stable + is controller - extend (controller always extends)",
 			parentState: &drift.ParentState{
 				HasObservedGeneration: true,
 				Generation:            5,
@@ -41,7 +41,7 @@ func TestPropagator_isOrigin(t *testing.T) {
 			},
 			username:      controllerUser,
 			childUpdaters: []string{controllerHash},
-			wantOrigin:    true,
+			wantOrigin:    false,
 		},
 		{
 			name: "has obsGen + reconciling + is controller - extend",

--- a/test/e2e/crossplane/install-deps.sh
+++ b/test/e2e/crossplane/install-deps.sh
@@ -36,7 +36,8 @@ helm upgrade --install crossplane crossplane-stable/crossplane \
     --timeout "${TIMEOUT}"
 
 log "Waiting for Crossplane to be ready..."
-kubectl wait --for=condition=ready pod -l app=crossplane -n "${CROSSPLANE_NAMESPACE}" --timeout="${TIMEOUT}"
+kubectl rollout status deployment/crossplane -n "${CROSSPLANE_NAMESPACE}" --timeout="${TIMEOUT}"
+kubectl rollout status deployment/crossplane-rbac-manager -n "${CROSSPLANE_NAMESPACE}" --timeout="${TIMEOUT}"
 
 # Install provider-nop
 log "Installing provider-nop..."

--- a/test/e2e/kubernetes/e2e_approval_test.go
+++ b/test/e2e/kubernetes/e2e_approval_test.go
@@ -445,9 +445,22 @@ func TestRejectionOverridesApproval(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("Added rejection annotation (approval still present)")
 
+	// Wait for Deployment to stabilize after annotation update.
+	// Adding the annotation bumps the Deployment's generation. Until the controller
+	// reconciles (gen == obsGen), any controller update to the RS is "expected
+	// reconciliation", not drift — so the rejection would never be checked.
+	ktesting.Eventually(t, func() (bool, string) {
+		dep, err = clientset.AppsV1().Deployments(enforceNS).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("error getting deployment: %v", err)
+		}
+		if dep.Status.ObservedGeneration != dep.Generation {
+			return false, fmt.Sprintf("not stable: gen=%d, obsGen=%d", dep.Generation, dep.Status.ObservedGeneration)
+		}
+		return true, "deployment stabilized after rejection annotation"
+	}, defaultTimeout, defaultInterval, "deployment should stabilize after adding rejection")
+
 	// Verify both annotations exist
-	dep, err = clientset.AppsV1().Deployments(enforceNS).Get(ctx, name, metav1.GetOptions{})
-	require.NoError(t, err)
 	assert.Contains(t, dep.Annotations, approval.ApprovalsAnnotation, "approval should still be present")
 	assert.Contains(t, dep.Annotations, approval.RejectionsAnnotation, "rejection should be present")
 

--- a/test/e2e/kubernetes/e2e_policy_test.go
+++ b/test/e2e/kubernetes/e2e_policy_test.go
@@ -336,8 +336,8 @@ func TestPolicyModeUpdate(t *testing.T) {
 	}, defaultTimeout, defaultInterval, "drift should be blocked in enforce mode")
 	t.Log("Drift blocked as expected (enforce mode)")
 
-	// Reset RS to 1 for next test
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	// Reset RS to 1 for next test (use DefaultBackoff — controller activity causes rapid conflicts)
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		rs, err := clientset.AppsV1().ReplicaSets(updateNS).Get(ctx, rsName, metav1.GetOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary
- Confirmed controllers always extend the parent's trace, regardless of parent state (stable or reconciling)
- Previously, `isOrigin()` treated "confirmed controller + parent stable" as a new origin, resetting the trace chain
- This caused Crossplane's convergence updates (e.g. adding `resourceRefs`) to reset child traces when the parent had already stabilized

## Rationale
A controller's action is always causally linked to the parent. Whether the action is expected (parent reconciling) or drift (parent stable) doesn't change the causal chain. Trace propagation and drift detection are separate concerns.

## Test plan
- [x] Unit test updated: "has obsGen + stable + is controller" now expects `wantOrigin: false`
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)